### PR TITLE
Fix typewriter phase reset and fade

### DIFF
--- a/src/components/TypewriterPonto.tsx
+++ b/src/components/TypewriterPonto.tsx
@@ -4,23 +4,38 @@ import "./TypewriterPonto.css";
 type Phase = "typing" | "waiting" | "deleting";
 
 const defaultVariants = ["PONTO.", "ac.", "ponto.ac."];
-const enzoVariants = ["enzo.", "enzo, the dude."];
+const enzoVariants = ["enzo.", "enzo, the dude.", "the dude."];
+const zadigVariants = ["zadig.", "z."];
 
 const TypewriterPonto = ({
   overrideText,
+  animate = true,
 }: {
   overrideText?: string | null;
+  animate?: boolean;
 }) => {
-  const isDynamic = overrideText === "enzo";
-  const variants = isDynamic ? enzoVariants : defaultVariants;
+  const isDynamic = overrideText === "enzo" || overrideText === "zadig";
+  const variants =
+    overrideText === "enzo"
+      ? enzoVariants
+      : overrideText === "zadig"
+      ? zadigVariants
+      : defaultVariants;
 
   const [displayText, setDisplayText] = useState("");
   const [phase, setPhase] = useState<Phase>("typing");
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  const currentText = overrideText ?? variants[currentIndex];
+  const currentText = isDynamic
+    ? variants[currentIndex]
+    : overrideText ?? variants[currentIndex];
 
   useEffect(() => {
+    if (!animate) {
+      setDisplayText(currentText);
+      return;
+    }
+
     let timeout: NodeJS.Timeout;
 
     if (phase === "typing") {
@@ -54,12 +69,16 @@ const TypewriterPonto = ({
     }
 
     return () => clearTimeout(timeout);
-  }, [phase, displayText, currentText, currentIndex, overrideText, variants]);
+  }, [phase, displayText, currentText, currentIndex, overrideText, variants, animate]);
 
-  // Reinicia ao mudar overrideText
+  // Reinicia ao mudar overrideText ou animacao
   useEffect(() => {
+    if (!animate) {
+      setDisplayText(currentText);
+      return;
+    }
     setPhase("deleting");
-  }, [overrideText]);
+  }, [overrideText, animate]);
 
   return (
     <h1 className="text-5xl md:text-7xl font-display tracking-[0.3em] relative text-center">
@@ -67,7 +86,7 @@ const TypewriterPonto = ({
       <span className="absolute inset-0 flex justify-center whitespace-nowrap">
         <span className="flex items-center gap-2">
           {displayText}
-          <span className="typewriter-cursor">|</span>
+          {animate && <span className="typewriter-cursor">|</span>}
         </span>
       </span>
     </h1>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -112,7 +112,12 @@ const Index = () => {
       <Navigation onReset={() => setActiveSection("home")} />
 
       <section className="h-screen flex flex-col items-center justify-center text-center gap-12 section-transition bg-white">
-        <TypewriterPonto
+        <div
+          className={`transition-opacity duration-500 ${
+            transitioning ? "opacity-0" : "opacity-100"
+          }`}
+        >
+          <TypewriterPonto
           overrideText={
             activeSection === "quem"
               ? "quem."
@@ -132,7 +137,13 @@ const Index = () => {
               ? "zadig"
               : null
           }
+          animate={
+            activeSection === "home" ||
+            activeSection === "comquem-enzo" ||
+            activeSection === "comquem-zadig"
+          }
         />
+        </div>
         <div
           className={`transition-opacity duration-500 ${
             transitioning ? "opacity-0" : "opacity-100"


### PR DESCRIPTION
## Summary
- reset typewriter phase only when section/animation changes
- fade typewriter during section transitions for smoother effects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e9336c883319f1780abc3853b0c