### PR TITLE
Add typewriter transition on section change

### DIFF
--- a/src/components/TypewriterPonto.tsx
+++ b/src/components/TypewriterPonto.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import "./TypewriterPonto.css";
 
-type Phase = "typing" | "waiting" | "deleting";
+type Phase = "typing" | "waiting" | "deleting" | "done";
 
 const defaultVariants = ["PONTO.", "ac.", "ponto.ac."];
 const enzoVariants = ["enzo.", "enzo, the dude.", "the dude."];
@@ -10,9 +10,11 @@ const zadigVariants = ["zadig.", "z."];
 const TypewriterPonto = ({
   overrideText,
   animate = true,
+  loop = true,
 }: {
   overrideText?: string | null;
   animate?: boolean;
+  loop?: boolean;
 }) => {
   const isDynamic = overrideText === "enzo" || overrideText === "zadig";
   const variants =
@@ -44,12 +46,16 @@ const TypewriterPonto = ({
           setDisplayText(currentText.slice(0, displayText.length + 1));
         }, 150);
       } else {
-        setPhase("waiting");
+        setPhase(loop ? "waiting" : "done");
       }
     }
 
-    if (phase === "waiting" && animate) {
+    if (phase === "waiting" && animate && loop) {
       timeout = setTimeout(() => setPhase("deleting"), 1000);
+    }
+
+    if (phase === "done") {
+      // Do nothing, animation finished
     }
 
     if (phase === "deleting") {
@@ -75,6 +81,7 @@ const TypewriterPonto = ({
     overrideText,
     variants,
     animate,
+    loop,
     isDynamic,
   ]);
 
@@ -87,7 +94,7 @@ const TypewriterPonto = ({
     }
     setCurrentIndex(0);
     setPhase("deleting");
-  }, [overrideText, animate]);
+  }, [overrideText, animate, loop]);
 
   return (
     <h1 className="text-5xl md:text-7xl font-display tracking-[0.3em] relative text-center">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -137,7 +137,8 @@ const Index = () => {
                 ? "zadig"
                 : null
             }
-            animate={
+            animate={true}
+            loop={
               activeSection === "home" ||
               activeSection === "comquem-enzo" ||
               activeSection === "comquem-zadig"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -110,5 +111,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add looping toggle to `TypewriterPonto` for single-run animations
- play animation when navigating to `quem`, `o que`, or `com quem`
- fix lint issues in command and textarea components
- convert Tailwind config to use ESM plugin import

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848bedd62188331a8ba08322eb20b99